### PR TITLE
Add Event Triggers to `content` Filter

### DIFF
--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -2122,7 +2122,9 @@ class Pico
                         $pageData = &$pages[$page];
                         if (!isset($pageData['content'])) {
                             $markdown = $pico->prepareFileContent($pageData['raw_content'], $pageData['meta']);
+                            $this->triggerEvent('onContentPrepared', array(&$markdown));
                             $pageData['content'] = $pico->parseFileContent($markdown);
+                            $this->triggerEvent('onContentParsed', array(&$pageData['content']));
                         }
                         return $pageData['content'];
                     }


### PR DESCRIPTION
In this merge I add important event triggers to improve the consistency in the functionality of PicoCMS. Previously, the `onContentPrepared` and `onContentParsed` events were only triggered when a page was called directly. 

This limitation led to problems with plugins that rely on these events, especially if the content was processed via the internal Twig filter `content`. The added event triggers in the `content` filter ensure that all plugins involved in content creation work smoothly even when the `content` filter is used. 

This change ensures broader and more reliable plugin compatibility within PicoCMS.