### PR TITLE
Enhanced Sorting by Nested Meta Values in Pages

### DIFF
--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -1830,11 +1830,22 @@ class Pico
         if ($orderBy === 'meta') {
             // sort by arbitrary meta value
             $orderByMeta = $this->getConfig('pages_order_by_meta');
-            uasort($this->pages, function ($a, $b) use ($alphaSortClosure, $order, $orderByMeta) {
-                $aSortValue = isset($a['meta'][$orderByMeta]) ? $a['meta'][$orderByMeta] : null;
+            // Split the configuration value into an array of keys to allow sorting by nested meta values.
+            $orderByMetaKeys = explode('.', $orderByMeta);
+
+            uasort($this->pages, function ($a, $b) use ($alphaSortClosure, $order, $orderByMetaKeys) {
+                $aMeta = $a['meta'];
+                $bMeta = $b['meta'];
+                // Iterate through the meta keys to drill down into nested arrays for the final sort value.
+                foreach ($orderByMetaKeys as $key) {
+                    $aMeta = isset($aMeta[$key]) ? $aMeta[$key] : null;
+                    $bMeta = isset($bMeta[$key]) ? $bMeta[$key] : null;
+                }
+
+                $aSortValue = $aMeta;
                 $aSortValueNull = ($aSortValue === null);
 
-                $bSortValue = isset($b['meta'][$orderByMeta]) ? $b['meta'][$orderByMeta] : null;
+                $bSortValue = $bMeta;
                 $bSortValueNull = ($bSortValue === null);
 
                 $cmp = 0;


### PR DESCRIPTION
This pull request introduces an enhancement to the sorting functionality within pages. Previously, sorting was limited to top-level meta values. With this update, the sorting logic now supports nested meta values, providing greater flexibility and precision in organizing content.

Key Changes:

- Extended the pages_order_by_meta configuration to interpret dot-separated strings as paths to nested meta values.
- Updated the sorting algorithm to recursively access nested meta values based on the provided path.

This enhancement ensures a more dynamic and versatile approach to content organization, particularly beneficial for complex page structures with deeply nested meta data.